### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Besides Midea itself other vendors of these type of appliances are also using th
 * Carrier
 * Toshiba
 * Idema
+* Dimstal/Simando
 
 This design of a custom dongle can be used to replace the orignal dongle with a type A USB connector. The version with with a JST-XH connector needs a slight modification.
 


### PR DESCRIPTION
Added Dimstal/Simando to the example vendor list. To clarify and save the info its also a midea AC. My monoblock model (SMND-PAC-12) has no USB-Plug, but the 4 pin Header on the Control/Display-PCB is populated and working.